### PR TITLE
PTC: Custom revenue Insight Report

### DIFF
--- a/PTC/SND01/Report/Custom Revenue Insight Report/RPRO_RC_LINE_CBILL_V.sql
+++ b/PTC/SND01/Report/Custom Revenue Insight Report/RPRO_RC_LINE_CBILL_V.sql
@@ -29,8 +29,8 @@ SELECT /* LEADING(rrl,rrb)*/
        ,rrb.f_cumm_bill_amt 
 FROM rpro_rc_line_g rrl ,
      bill rrb
-WHERE rrb.line_id = rrl.id
-AND   rrb.rc_id   = rrl.rc_id
-AND   rrl.rc_id  != 0;
+WHERE rrb.line_id(+) = rrl.id
+AND   rrb.rc_id(+)   = rrl.rc_id
+AND   rrl.rc_id     != 0;
 
 /


### PR DESCRIPTION
Since we put inner join , it was taking only the records which is billed , where it is causing reporting because of not picking the unbilled records, Now we have chaned to outer join to consider records either billed/unbilled.